### PR TITLE
Add jitpack.yml for Java 17

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+before_install:
+  - export SDKMAN_DIR="/home/jitpack/sdkman" && curl -s "https://get.sdkman.io" | bash
+  - source "/home/jitpack/sdkman/bin/sdkman-init.sh"
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open


### PR DESCRIPTION
Adding a jitpack.yml file will allow this mod to build on Jitpack with Java 17 & people to make mods depending on this one using [Jitpack](https://jitpack.io/#Noaaan/MythicMetals).

Without the .yml file to tell Jitpack what version of Java to use it fails:
https://jitpack.io/com/github/Noaaan/MythicMetals/0.11.0/build.log