### PR TITLE
Explosive Enhancement Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     // Cardinal Components
     modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}")
     modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}")
+
+    //Explosive Enhancement
+    modApi("maven.modrinth:explosive-enhancement:${project.ee_version}")
 }
 
 sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,3 +48,6 @@ cpa_version = 1.0.0
 # EMI
 # https://github.com/emilyploszaj/emi
 emi_version=1.0.14+1.20.1
+# Explosive Enhancement
+# https://modrinth.com/mod/explosive-enhancement
+ee_version=1.2.1-1.20.x

--- a/src/main/java/nourl/mythicmetals/compat/ExplosiveCompat.java
+++ b/src/main/java/nourl/mythicmetals/compat/ExplosiveCompat.java
@@ -1,0 +1,10 @@
+package nourl.mythicmetals.compat;
+
+import net.minecraft.world.World;
+import net.superkat.explosiveenhancement.api.ExplosiveApi;
+
+public class ExplosiveCompat {
+    public static void spawnParticles(World world, double x, double y, double z, float power) {
+        ExplosiveApi.spawnParticles(world, x, y, z, power, false, true, true);
+    }
+}

--- a/src/main/java/nourl/mythicmetals/misc/EpicExplosion.java
+++ b/src/main/java/nourl/mythicmetals/misc/EpicExplosion.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.explosion.Explosion;
 import nourl.mythicmetals.data.MythicTags;
 import org.jetbrains.annotations.Nullable;
@@ -45,6 +46,8 @@ public final class EpicExplosion {
         if (exploder != null) {
             explosion = new Explosion(world, exploder, x, y, z, radius, false, Explosion.DestructionType.DESTROY_WITH_DECAY);
         }
+
+        MythicParticleSystem.EXPLOSIVE_EXPLOSION.spawn(world, new Vec3d(x, y, z), (float) radius);
 
         GameProfile playerId = cause != null ? cause.getGameProfile() : CommonProtection.UNKNOWN;
 

--- a/src/main/java/nourl/mythicmetals/misc/MythicParticleSystem.java
+++ b/src/main/java/nourl/mythicmetals/misc/MythicParticleSystem.java
@@ -4,9 +4,11 @@ import io.wispforest.owo.particles.ClientParticles;
 import io.wispforest.owo.particles.systems.ParticleSystem;
 import io.wispforest.owo.particles.systems.ParticleSystemController;
 import io.wispforest.owo.util.VectorRandomUtils;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import nourl.mythicmetals.compat.ExplosiveCompat;
 
 import java.util.Random;
 
@@ -107,6 +109,11 @@ public class MythicParticleSystem {
         ClientParticles.reset();
     });
 
+    public static final ParticleSystem<Float> EXPLOSIVE_EXPLOSION = CONTROLLER.register(Float.class, (world, pos, power) -> {
+        if(FabricLoader.getInstance().isModLoaded("explosiveenhancement")) {
+            ExplosiveCompat.spawnParticles(world, pos.x, pos.y, pos.z, power);
+        }
+    });
 
     public static void init() {
     }


### PR DESCRIPTION
Adds the Explosive Enhancement explosion effect to the banglum nuke explosion.

I ask that you review the code before merging, just to make sure I didn't miss anything important. The banglum tnt explosion actually already worked with Explosive Enhancement, because it uses Minecraft's own explosion system, which is where Explosive Enhancement mixes into.

I've tested this in various environments. Some include:
- Singleplayer with and without Explosive Enhancement.
- Server has MM and the player has just MM.
- Server has MM and the player has both MM and EE.
- Server has both MM and EE(does nothing bc client side) and the player has both MM and EE.

I did not test it with multiple players on a server, because I don't really have the ability to do that. 

Lots of changes on Explosive Enhancement's side went into this, so hopefully it'll turn out well!