### PR TITLE
Added support for Trinkets API

### DIFF
--- a/src/main/resources/data/trinkets/entities/mythicmetals.json
+++ b/src/main/resources/data/trinkets/entities/mythicmetals.json
@@ -1,0 +1,8 @@
+{
+  "entities": [
+    "player"
+  ],
+  "slots": [
+    "chest/cape"
+  ]
+}

--- a/src/main/resources/data/trinkets/tags/items/chest/cape.json
+++ b/src/main/resources/data/trinkets/tags/items/chest/cape.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "mythicmetals:celestium_elytra"
+  ]
+}


### PR DESCRIPTION
All that was needed for Issue #181 was adding the tags for the Celestium Elytra for it to be recognized as elytra by the Trinkets API.

Tested in game and was able to apply the Elytra to a trinket slot (using [Elytra Slot mod](https://modrinth.com/mod/elytra-slot))