### PR TITLE
Tag datagen: update raw ores; add dusts + nuggets

### DIFF
--- a/src/main/generated/data/c/tags/items/adamantite_nuggets.json
+++ b/src/main/generated/data/c/tags/items/adamantite_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:adamantite_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/aquarium_nuggets.json
+++ b/src/main/generated/data/c/tags/items/aquarium_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:aquarium_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/banglum_nuggets.json
+++ b/src/main/generated/data/c/tags/items/banglum_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:banglum_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/bronze_nuggets.json
+++ b/src/main/generated/data/c/tags/items/bronze_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:bronze_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/carmot_nuggets.json
+++ b/src/main/generated/data/c/tags/items/carmot_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:carmot_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/celestium_nuggets.json
+++ b/src/main/generated/data/c/tags/items/celestium_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:celestium_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/copper_dusts.json
+++ b/src/main/generated/data/c/tags/items/copper_dusts.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:copper_dusts"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/copper_nuggets.json
+++ b/src/main/generated/data/c/tags/items/copper_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:copper_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/durasteel_nuggets.json
+++ b/src/main/generated/data/c/tags/items/durasteel_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:durasteel_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/dusts.json
+++ b/src/main/generated/data/c/tags/items/dusts.json
@@ -1,0 +1,30 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts",
+    "#mythicmetals:dusts"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/hallowed_nuggets.json
+++ b/src/main/generated/data/c/tags/items/hallowed_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:hallowed_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/kyber_nuggets.json
+++ b/src/main/generated/data/c/tags/items/kyber_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:kyber_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/manganese_nuggets.json
+++ b/src/main/generated/data/c/tags/items/manganese_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:manganese_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/metallurgium_nuggets.json
+++ b/src/main/generated/data/c/tags/items/metallurgium_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:metallurgium_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/midas_gold_nuggets.json
+++ b/src/main/generated/data/c/tags/items/midas_gold_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:midas_gold_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/mythril_nuggets.json
+++ b/src/main/generated/data/c/tags/items/mythril_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:mythril_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/nuggets.json
+++ b/src/main/generated/data/c/tags/items/nuggets.json
@@ -1,0 +1,30 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets",
+    "#mythicmetals:nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/orichalcum_nuggets.json
+++ b/src/main/generated/data/c/tags/items/orichalcum_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:orichalcum_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/osmium_nuggets.json
+++ b/src/main/generated/data/c/tags/items/osmium_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:osmium_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/palladium_nuggets.json
+++ b/src/main/generated/data/c/tags/items/palladium_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:palladium_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/platinum_nuggets.json
+++ b/src/main/generated/data/c/tags/items/platinum_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:platinum_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/prometheum_nuggets.json
+++ b/src/main/generated/data/c/tags/items/prometheum_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:prometheum_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/quadrillum_nuggets.json
+++ b/src/main/generated/data/c/tags/items/quadrillum_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:quadrillum_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/raw_ores.json
+++ b/src/main/generated/data/c/tags/items/raw_ores.json
@@ -1,0 +1,30 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores",
+    "#mythicmetals:raw_ores"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/runite_nuggets.json
+++ b/src/main/generated/data/c/tags/items/runite_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:runite_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/silver_nuggets.json
+++ b/src/main/generated/data/c/tags/items/silver_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:silver_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/star_platinum_nuggets.json
+++ b/src/main/generated/data/c/tags/items/star_platinum_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:star_platinum_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/steel_nuggets.json
+++ b/src/main/generated/data/c/tags/items/steel_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:steel_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/stormyx_nuggets.json
+++ b/src/main/generated/data/c/tags/items/stormyx_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:stormyx_nuggets"
+  ]
+}

--- a/src/main/generated/data/c/tags/items/tin_nuggets.json
+++ b/src/main/generated/data/c/tags/items/tin_nuggets.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#mythicmetals:tin_nuggets"
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/adamantite_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/adamantite_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:adamantite_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/aquarium_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/aquarium_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:aquarium_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/banglum_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/banglum_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:banglum_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/bronze_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/bronze_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:bronze_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/carmot_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/carmot_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:carmot_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/celestium_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/celestium_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:celestium_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/copper_dusts.json
+++ b/src/main/generated/data/mythicmetals/tags/items/copper_dusts.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:copper_dust",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/copper_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/copper_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:copper_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/durasteel_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/durasteel_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:durasteel_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/dusts.json
+++ b/src/main/generated/data/mythicmetals/tags/items/dusts.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:copper_dust",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/hallowed_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/hallowed_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:hallowed_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/kyber_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/kyber_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:kyber_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/manganese_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/manganese_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:manganese_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/metallurgium_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/metallurgium_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:metallurgium_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/midas_gold_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/midas_gold_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:midas_gold_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/mythril_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/mythril_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:mythril_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/nuggets.json
@@ -1,0 +1,109 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:adamantite_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:aquarium_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:banglum_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:bronze_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:carmot_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:celestium_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:durasteel_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:hallowed_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:kyber_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:manganese_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:metallurgium_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:midas_gold_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:mythril_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:orichalcum_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:osmium_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:palladium_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:platinum_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:prometheum_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:quadrillum_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:runite_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:silver_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:star_platinum_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:steel_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:stormyx_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:tin_nugget",
+      "required": false
+    },
+    {
+      "id": "mythicmetals:copper_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/orichalcum_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/orichalcum_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:orichalcum_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/osmium_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/osmium_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:osmium_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/palladium_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/palladium_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:palladium_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/platinum_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/platinum_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:platinum_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/prometheum_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/prometheum_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:prometheum_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/quadrillum_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/quadrillum_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:quadrillum_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/runite_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/runite_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:runite_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/silver_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/silver_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:silver_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/star_platinum_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/star_platinum_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:star_platinum_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/steel_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/steel_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:steel_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/stormyx_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/stormyx_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:stormyx_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/generated/data/mythicmetals/tags/items/tin_nuggets.json
+++ b/src/main/generated/data/mythicmetals/tags/items/tin_nuggets.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "mythicmetals:tin_nugget",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/nourl/mythicmetals/data/MythicItemDataProvider.java
+++ b/src/main/java/nourl/mythicmetals/data/MythicItemDataProvider.java
@@ -13,6 +13,7 @@ import nourl.mythicmetals.item.ItemSet;
 import nourl.mythicmetals.item.MythicItems;
 import nourl.mythicmetals.item.tools.MythicTools;
 import nourl.mythicmetals.item.tools.ToolSet;
+import nourl.mythicmetals.misc.RegistryHelper;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -83,18 +84,70 @@ public class MythicItemDataProvider extends FabricTagProvider.ItemTagProvider {
              * #mythicmetals:raw_adamantite_ores
              * #c:raw_adamantite_ores
              * #mythicmetals:raw_ores
+             * At the end #mythicmetals:raw_ores is nested into #c:raw_ores
              */
+            var modRawOreTag = MythicMetalsData.createModItemTag("raw_ores");
+            var commonRawOreTag = MythicMetalsData.createCommonItemTag("raw_ores");
             if (itemSet.getRawOre() != null) {
                 var string = "raw_" + name + "_ores";
-                var modRawOreTag = MythicMetalsData.createModItemTag("raw_ores");
-
                 var modTag = MythicMetalsData.createModItemTag(string);
                 var commonTag = MythicMetalsData.createCommonItemTag(string);
                 getOrCreateTagBuilder(modTag).add(itemSet.getRawOre());
                 getOrCreateTagBuilder(modRawOreTag).add(itemSet.getRawOre());
                 getOrCreateTagBuilder(commonTag).addTag(modTag);
             }
+            getOrCreateTagBuilder(commonRawOreTag).addTag(modRawOreTag);
+
+            /*
+             * Create (optional) dust tags. Example:
+             * Adamantite Dust is added to the following:
+             * #mythicmetals:adamantite_dusts
+             * #c:adamantite_dusts
+             * #mythicmetals:dusts
+             * At the end #mythicmetals:dusts is nested into #c:dusts
+             */
+            var modDustsTag = MythicMetalsData.createModItemTag("dusts");
+            var commonDustsTag = MythicMetalsData.createCommonItemTag("dusts");
+            if (itemSet.getDust() != null) {
+                var string = name + "_dusts";
+                var modTag = MythicMetalsData.createModItemTag(string);
+                var commonTag = MythicMetalsData.createCommonItemTag(string);
+                getOrCreateTagBuilder(modTag).addOptional(reverseLookup(itemSet.getDust()));
+                getOrCreateTagBuilder(modDustsTag).addOptional(reverseLookup(itemSet.getDust()));
+                getOrCreateTagBuilder(commonTag).addTag(modTag);
+            }
+            getOrCreateTagBuilder(commonDustsTag).addTag(modDustsTag);
+
+            /*
+             * Create (optional) nugget tags. Example:
+             * Adamantite Nugget is added to the following:
+             * #mythicmetals:adamantite_nuggets
+             * #c:adamantite_nuggets
+             * #mythicmetals:nuggets
+             * At the end #mythicmetals:nuggets is nested into #c:nuggets
+             */
+            var modNuggetsTag = MythicMetalsData.createModItemTag("nuggets");
+            var commonNuggetsTag = MythicMetalsData.createCommonItemTag("nuggets");
+            if (itemSet.getNugget() != null) {
+                var string = name + "_nuggets";
+                var modTag = MythicMetalsData.createModItemTag(string);
+                var commonTag = MythicMetalsData.createCommonItemTag(string);
+                getOrCreateTagBuilder(modTag).addOptional(reverseLookup(itemSet.getNugget()));
+                getOrCreateTagBuilder(modNuggetsTag).addOptional(reverseLookup(itemSet.getNugget()));
+                getOrCreateTagBuilder(commonTag).addTag(modTag);
+            }
+            getOrCreateTagBuilder(commonNuggetsTag).addTag(modNuggetsTag);
         });
+
+        /*
+         * Edge cases for Copper
+         */
+        getOrCreateTagBuilder(MythicMetalsData.createModItemTag("copper_dusts")).addOptional(RegistryHelper.id("copper_dust"));
+        getOrCreateTagBuilder(MythicMetalsData.createCommonItemTag("copper_dusts")).addTag(MythicMetalsData.createModItemTag("copper_dusts"));
+        getOrCreateTagBuilder(MythicMetalsData.createModItemTag("dusts")).addOptional(RegistryHelper.id("copper_dust"));
+        getOrCreateTagBuilder(MythicMetalsData.createModItemTag("copper_nuggets")).addOptional(RegistryHelper.id("copper_nugget"));
+        getOrCreateTagBuilder(MythicMetalsData.createCommonItemTag("copper_nuggets")).addTag(MythicMetalsData.createModItemTag("copper_nuggets"));
+        getOrCreateTagBuilder(MythicMetalsData.createModItemTag("nuggets")).addOptional(RegistryHelper.id("copper_nugget"));
 
         ReflectionUtils.iterateAccessibleStaticFields(MythicItems.Mats.class, Item.class, (item, name, field) -> {
             if (item.equals(MythicItems.Mats.STARRITE) || item.equals(MythicItems.Mats.UNOBTAINIUM) || item.equals(MythicItems.Mats.MORKITE)) {

--- a/src/main/java/nourl/mythicmetals/item/ItemSet.java
+++ b/src/main/java/nourl/mythicmetals/item/ItemSet.java
@@ -1,11 +1,9 @@
 package nourl.mythicmetals.item;
 
 import io.wispforest.owo.itemgroup.OwoItemSettings;
-import io.wispforest.owo.util.TagInjector;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
-import net.minecraft.util.Identifier;
 import nourl.mythicmetals.MythicMetals;
 import nourl.mythicmetals.misc.RegistryHelper;
 import java.util.function.Consumer;
@@ -50,8 +48,6 @@ public class ItemSet {
         }
         if (nuggetItem != null) {
             Registry.register(Registries.ITEM, RegistryHelper.id(name + "_nugget"), nuggetItem);
-            // Conditionally add nuggets to nuggets tag
-            TagInjector.inject(Registries.ITEM, new Identifier("c", "nuggets"), nuggetItem);
         }
         if (dustItem != null) {
             Registry.register(Registries.ITEM, RegistryHelper.id(name + "_dust"), dustItem);


### PR DESCRIPTION
This PR mainly updates `MythicItemDataProvider`:
- `#mythicmetals:raw_ores` is now added to `#c:raw_ores`, just as `#mythicmetals:ingots` is added to `#c:ingots`
- Tags for Dusts and Nuggets are now generated
  - As these can be disabled in the mod config, each tag entry is marked as optional (not required by default)
  - `#mythicmetals:dusts` is added to `#c:dusts` and `#mythicmetals:nuggets` is added to `#c:nuggets` as well
  - Copper Dust and Nuggets have to be handled separately as they are not included in the `ItemSet` array returned by `ReflectionUtils`, and they're not registered during datagen for some reason? (unlike all other Dusts and Nuggets)
- The JSON files for the resulting `#c:dusts`, `#c:nuggets`, and `#c:raw_ores` look a little broken, but so does `#c:ingots` so I guess it's fine?

`ItemSet` has been updated as well, as tag injection for nuggets is no longer necessary.

This fully fixes #183.